### PR TITLE
Mods is a new class that makes changes to Unit stats.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ ConsoleApplication1/ConsoleApplication1.vcxproj
 ConsoleApplication1/ConsoleApplication1.vcxproj.filters
 ConsoleApplication1/ConsoleApplication1.vcxproj.user
 ConsoleApplication1/ConsoleApplication1.sln
+ConsoleApplication1/ClassDiagram.cd

--- a/ConsoleApplication1/Inventory.cpp
+++ b/ConsoleApplication1/Inventory.cpp
@@ -3,49 +3,49 @@
 
 Inventory::Inventory(std::string name)
 {
-	this->name = name;
-	maxSize = NULL;
-	updateQuantityMap();
-	updateDetailedChoiceVector();
+    this->name = name;
+    maxSize = NULL;
+    updateQuantityMap();
+    updateDetailedChoiceVector();
 }
 
 Inventory::Inventory(std::string name, int maxSize)
 {
-	setMaxSize(maxSize);
-	this->name = name;
-	updateQuantityMap();
-	updateDetailedChoiceVector();
+    setMaxSize(maxSize);
+    this->name = name;
+    updateQuantityMap();
+    updateDetailedChoiceVector();
 }
 
 //returns true if maxSize is set
 bool Inventory::hasMaxSize()
 {
-	if (maxSize == NULL)
-		return false;
-	else
-		return true;
+    if (maxSize == NULL)
+        return false;
+    else
+        return true;
 }
 
 //returns true if the inv is empty, else returns false
 bool Inventory::isEmpty()
 {
-	if (inv.size() == 0)
-		return true;
-	else
-		return false;
+    if (inv.size() == 0)
+        return true;
+    else
+        return false;
 }
 
 //returns true if the inv is full, else returns false
 bool Inventory::isFull()
 {
-	if (maxSize != NULL)
-	{
-		if (inv.size() == maxSize)
-			return true;
-		else
-			return false;
-	}
-	return false;
+    if (maxSize != NULL)
+    {
+        if (inv.size() == maxSize)
+            return true;
+        else
+            return false;
+    }
+    return false;
 }
 
 
@@ -53,27 +53,27 @@ bool Inventory::isFull()
 //returns maxSize
 int Inventory::setMaxSize(int size)
 {
-	maxSize = size;
-	return maxSize;
+    maxSize = size;
+    return maxSize;
 }
 
 //returns the maxSize of the inventory
 int Inventory::getMaxSize()
 {
-	return maxSize;
+    return maxSize;
 }
 
 //returns current size of the inventory
 int Inventory::getCurrSize()
 {
-	return inv.size();
+    return inv.size();
 }
 
 //sets maxSize to NULL
 void Inventory::clearSize()
 {
-	maxSize = NULL;
-	return;
+    maxSize = NULL;
+    return;
 }
 
 //Adds a pointer to an obj quantity times.
@@ -81,12 +81,12 @@ void Inventory::clearSize()
 // not new objs.
 void Inventory::addItem(std::shared_ptr<GameObject> obj, int quantity)
 {
-	for (int i = 0; i < quantity && !isFull(); i++)
-	{
-		inv.push_back(obj);
-	}
-	updateQuantityMap();
-	return;
+    for (int i = 0; i < quantity && !isFull(); i++)
+    {
+        inv.push_back(obj);
+    }
+    updateQuantityMap();
+    return;
 }
 
 //Remove a Game Object from an inventory, based on obj pointer.
@@ -94,22 +94,22 @@ void Inventory::addItem(std::shared_ptr<GameObject> obj, int quantity)
 // If no object is found, returns NULL.
 std::shared_ptr<GameObject> Inventory::removeItem(std::shared_ptr<GameObject> obj)
 {
-	if (!isEmpty())
-	{
-		for (auto i = begin(inv); i != end(inv);)
-		{
-			if (*i == obj)
-			{
-				obj = *i;
-				i = inv.erase(i);
-				updateQuantityMap();
-				return obj;
-			}
-			else
-				++i;
-		}
-	}
-	return NULL;
+    if (!isEmpty())
+    {
+        for (auto i = begin(inv); i != end(inv);)
+        {
+            if (*i == obj)
+            {
+                obj = *i;
+                i = inv.erase(i);
+                updateQuantityMap();
+                return obj;
+            }
+            else
+                ++i;
+        }
+    }
+    return NULL;
 }
 
 //Remove a Game Object based on the "name" property of the obj.
@@ -117,52 +117,52 @@ std::shared_ptr<GameObject> Inventory::removeItem(std::shared_ptr<GameObject> ob
 // If no object is found, returns NULL.
 std::shared_ptr<GameObject> Inventory::removeItem(std::string itemName)
 {
-	std::shared_ptr<GameObject> obj;
-	if (!isEmpty())
-	{
-		for (auto i = begin(inv); i != end(inv);)
-		{
-			if ((*i)->name == itemName || (*i)->getChoiceDetailString() == itemName)
-			{
-				obj = *i;
-				i = inv.erase(i);
-				updateQuantityMap();
-				return obj;
-			}
-			else
-				++i;
-		}
-	}
-	return NULL;
+    std::shared_ptr<GameObject> obj;
+    if (!isEmpty())
+    {
+        for (auto i = begin(inv); i != end(inv);)
+        {
+            if ((*i)->name == itemName || (*i)->getChoiceDetailString() == itemName)
+            {
+                obj = *i;
+                i = inv.erase(i);
+                updateQuantityMap();
+                return obj;
+            }
+            else
+                ++i;
+        }
+    }
+    return NULL;
 }
 
 //Takes string matching a GameObject name or choiceDetailString, and searches for it in the 
 // fromInv. If found, it adds a copy of the pointer to the toInv and then
 // removes the pointer from the fromInv.
 void Inventory::transferItem(std::string itemName,
-	Inventory& fromInv, Inventory& toInv)
+    Inventory& fromInv, Inventory& toInv)
 {
-	if (!toInv.isFull() && !fromInv.isEmpty())
-	{
-		for (auto i = begin(fromInv.inv); i != end(fromInv.inv);)
-		{
-			if ((*i)->name == itemName)
-			{
-				toInv.addItem(*i);
-				fromInv.removeItem(*i);
-				return;
-			}
-			else if ((*i)->getChoiceDetailString() == itemName)
-			{
-				toInv.addItem(*i);
-				fromInv.removeItem(*i);
-				return;
-			}
-			else
-				++i;
-		}
-	}
-	return;
+    if (!toInv.isFull() && !fromInv.isEmpty())
+    {
+        for (auto i = begin(fromInv.inv); i != end(fromInv.inv);)
+        {
+            if ((*i)->name == itemName)
+            {
+                toInv.addItem(*i);
+                fromInv.removeItem(*i);
+                return;
+            }
+            else if ((*i)->getChoiceDetailString() == itemName)
+            {
+                toInv.addItem(*i);
+                fromInv.removeItem(*i);
+                return;
+            }
+            else
+                ++i;
+        }
+    }
+    return;
 }
 
 //Creates or Updates a Quantity Map, which is a map<string, string>
@@ -171,23 +171,23 @@ void Inventory::transferItem(std::string itemName,
 // a string so that it is easy to pass into a PrntScrn slot.
 void Inventory::updateQuantityMap()
 {
-	quantityMap.clear();
-	quantityMap["title"] = name; //name of the inventory
+    quantityMap.clear();
+    quantityMap["title"] = name; //name of the inventory
 
-	for (auto const& item : inv)
-	{
-		if (quantityMap.count(item->name) != 0)
-		{
-			int x = std::stoi(quantityMap[item->name]);
-			x += 1;
-			quantityMap[item->name] = std::to_string(x);
-		}
-		else
-		{
-			quantityMap[item->name] = "1";
-		}
-	}
-	return;
+    for (auto const& item : inv)
+    {
+        if (quantityMap.count(item->name) != 0)
+        {
+            int x = std::stoi(quantityMap[item->name]);
+            x += 1;
+            quantityMap[item->name] = std::to_string(x);
+        }
+        else
+        {
+            quantityMap[item->name] = "1";
+        }
+    }
+    return;
 }
 
 
@@ -196,18 +196,18 @@ void Inventory::updateQuantityMap()
 // it's key details based on that GameObjects choiceDetailString.
 std::vector<std::string>& Inventory::getDetailedChoiceVector()
 {
-	updateDetailedChoiceVector();
-	return detailedChoiceVector;
+    updateDetailedChoiceVector();
+    return detailedChoiceVector;
 }
 
 //Creates or updates a detailedChoiceVector of strings for use with the Prompt class.
 void Inventory::updateDetailedChoiceVector()
 {
-	detailedChoiceVector.clear();
-	for (auto const& item : inv)
-	{
-		detailedChoiceVector.push_back(item->getChoiceDetailString());
-	}
+    detailedChoiceVector.clear();
+    for (auto const& item : inv)
+    {
+        detailedChoiceVector.push_back(item->getChoiceDetailString());
+    }
 }
 
 //Returns a quantityChoiceVector of strings for use with the Prompt
@@ -215,54 +215,54 @@ void Inventory::updateDetailedChoiceVector()
 // equates to the number of instances of objs that share that name.
 std::vector<std::string>& Inventory::getQuantityChoiceVector()
 {
-	updateQuantityChoiceVector();
-	return quantityChoiceVector;
+    updateQuantityChoiceVector();
+    return quantityChoiceVector;
 }
 
 //Creates or updates a quantityChoiceVector of strings for use with the Prompt class.
 void Inventory::updateQuantityChoiceVector()
 {
-	quantityChoiceVector.clear();
+    quantityChoiceVector.clear();
 
-	for (auto const& x : quantityMap)
-	{
-		if (x.first != "title")
-			quantityChoiceVector.push_back(x.first);
-	} 
+    for (auto const& x : quantityMap)
+    {
+        if (x.first != "title")
+            quantityChoiceVector.push_back(x.first);
+    } 
 }
 
 //Returns a list of detail maps based on the objs in inv. The 'title' of the detail map
 //will be overwritten with a value indicating it's position
 std::vector<std::map<std::string, std::string>>& Inventory::getSlotDetailMaps()
 {
-	updateSlotDetailMaps();
-	return slotDetailMaps;
+    updateSlotDetailMaps();
+    return slotDetailMaps;
 }
 
 //Creates or updates a list of detail maps based on the objs in the inv.
 // This where the 'title' of the detail map will be overwritten with position data
 void Inventory::updateSlotDetailMaps()
 {
-	slotDetailMaps.clear();
-	int pos = 1;
-	for (auto const& item : inv)
-	{
-		std::map<std::string, std::string> tempMap = item->getSlotDetailMap();
-		tempMap["title"] = "Pos " + std::to_string(pos);
-		slotDetailMaps.push_back(tempMap);
-		pos++;
-	}
+    slotDetailMaps.clear();
+    int pos = 1;
+    for (auto const& item : inv)
+    {
+        std::map<std::string, std::string> tempMap = item->getSlotDetailMap();
+        tempMap["title"] = "Pos " + std::to_string(pos);
+        slotDetailMaps.push_back(tempMap);
+        pos++;
+    }
 }
 
 //Takes two int values, and swaps the pointers to the objs at those positions.
 //Note that this does not swap the actual objs, just the pointers to them.
 void Inventory::swapItems(int pos1, int pos2)
 {
-	if (pos1 > 0 && pos1 <= inv.size() && pos2 > 0 && pos2 <= inv.size())
-	{
-		std::shared_ptr<GameObject> temp = inv[pos1 - 1];
-		inv[pos1 - 1] = inv[pos2 - 1];
-		inv[pos2 - 1] = temp;
-	}
-	return;
+    if (pos1 > 0 && pos1 <= inv.size() && pos2 > 0 && pos2 <= inv.size())
+    {
+        std::shared_ptr<GameObject> temp = inv[pos1 - 1];
+        inv[pos1 - 1] = inv[pos2 - 1];
+        inv[pos2 - 1] = temp;
+    }
+    return;
 }

--- a/ConsoleApplication1/gameObjectClasses/Item.cpp
+++ b/ConsoleApplication1/gameObjectClasses/Item.cpp
@@ -1,6 +1,7 @@
 #include "Item.h"
 
-Item::Item(std::string name, itemType type, int durability, int hitPointModifier, int attackModifier, int defenseModifier)
+Item::Item(std::string name, itemType type, int durability, int hitPointModifier, int attackModifier, int defenseModifier,
+	std::vector<std::string> modKeys)
 	: GameObject(name)
 {
 	this->name = name;
@@ -9,4 +10,9 @@ Item::Item(std::string name, itemType type, int durability, int hitPointModifier
 	this->hitPointModifier = hitPointModifier;
 	this->attackModifier = attackModifier;
 	this->defenseModifier = defenseModifier;
+	//for the constructur, I need getEntry working. If anything ever needs child object,
+	// it will a string or list to be used in a getEntryConstructor that all objects will have.
+	
+	//this modlist thing is temporary! I'm justy trying it out for testing.
+	modList.emplace_back(Mod("mod1", Mod::statType::HITPOINTS, Mod::modType::ADD, 5, std::shared_ptr<GameObject>(this)));
 }

--- a/ConsoleApplication1/gameObjectClasses/Item.h
+++ b/ConsoleApplication1/gameObjectClasses/Item.h
@@ -1,17 +1,22 @@
 #pragma once
+#include <map>
+#include <vector>
+#include <string>
+#include "Mod.h"
 #include "GameObject.h"
 class Item :
     public GameObject
 {
 public:
     enum itemType { WEAPON, ARMOR, TRINKET };
-    Item(std::string name, itemType type, int durability, int hitPointModifier, int attackModifier, int defenseModifier);
+    Item(std::string name, itemType type, int durability, int hitPointModifier, int attackModifier, int defenseModifier,
+        std::vector<std::string> modKeys);
     itemType type;
     int hitPointModifier;
     int attackModifier;
     int defenseModifier;
     int durability;
-
+    std::vector<Mod> modList;
     
 };
 

--- a/ConsoleApplication1/gameObjectClasses/Mod.cpp
+++ b/ConsoleApplication1/gameObjectClasses/Mod.cpp
@@ -1,0 +1,19 @@
+#include "Mod.h"
+//
+//Mod::Mod(std::string name, statType stat, modType type, float value, std::shared_ptr<GameObject> owner)
+//    : GameObject(name)
+//{
+//    this->stat = stat;
+//    this->type = type;
+//    this->value = value;
+//    this->owner = owner;
+//}
+
+Mod::Mod(std::string name, statType stat, modType type, float value, std::shared_ptr<GameObject> owner)
+	: GameObject(name)
+{
+	this->stat = stat;
+	this->type = type;
+	this->value = value;
+	this->owner = owner;
+};

--- a/ConsoleApplication1/gameObjectClasses/Mod.h
+++ b/ConsoleApplication1/gameObjectClasses/Mod.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "GameObject.h"
+class Mod :
+    public GameObject
+{
+public:
+    enum statType { HITPOINTS, ATTACK, DEFENSE };
+    enum modType { ADD, MULTIPLY };
+    statType stat;
+    modType type;
+    float value;
+    std::shared_ptr<GameObject> owner;
+
+    Mod(std::string name, statType stat, modType type, float value, std::shared_ptr<GameObject> owner);
+};
+

--- a/ConsoleApplication1/gameObjectClasses/Unit.cpp
+++ b/ConsoleApplication1/gameObjectClasses/Unit.cpp
@@ -1,32 +1,34 @@
 #include "Unit.h"
 
-Unit::Unit(std::string name, std::string type, int hitPoints, int attack, int defense)
-	: GameObject(name)
+Unit::Unit(std::string name, std::string type, int baseHitPoints, int baseAttack, int baseDefense)
+    : GameObject(name)
 {
-	this->name = name;
-	this->type = type;
-	this->hitPoints = hitPoints;
-	this->attack = attack;
-	this->defense = defense;
-	weapon = NULL;
-	armor = NULL;
-	trinket = NULL;
+    this->name = name;
+    this->type = type;
+    this->baseHitPoints = baseHitPoints;
+    this->baseAttack = baseAttack;
+    this->baseDefense = baseDefense;
+    weapon = NULL;
+    armor = NULL;
+    trinket = NULL;
 }
 
 //Adds an item to one of the three item slots
 // depending on the on the item's ENUM itemType.
 void Unit::addItem(std::shared_ptr<Item> item)
 {
-	if (item->type == Item::itemType::WEAPON)
-		weapon = item;
-	else if (item->type == Item::itemType::ARMOR)
-		armor = item;
-	else if (item->type == Item::itemType::TRINKET)
-		trinket = item;
+    if (item->type == Item::itemType::WEAPON)
+        weapon = item;
+    else if (item->type == Item::itemType::ARMOR)
+        armor = item;
+    else if (item->type == Item::itemType::TRINKET)
+        trinket = item;
 
-	generateChoiceDetailString();
-	generateSlotDetailMap();
-	return;
+    addMods(item->modList);
+    updateMods();
+    generateChoiceDetailString();
+    generateSlotDetailMap();
+    return;
 }
 
 //Removes an item from one of the three item slots
@@ -34,36 +36,107 @@ void Unit::addItem(std::shared_ptr<Item> item)
 // Returns a pointer to the item that was removed.
 std::shared_ptr <Item> Unit::removeItem(Item::itemType type)
 {
-	std::shared_ptr <Item> temp;
+    std::shared_ptr <Item> temp;
 
-	if (type == Item::itemType::WEAPON)
-	{
-		temp = weapon;
-		weapon = NULL;
-	}
-	else if (type == Item::itemType::ARMOR)
-	{
-		temp = armor;
-		armor = NULL;
-	}
-	else if (type == Item::itemType::TRINKET)
-	{
-		temp = trinket;
-		trinket = NULL;
-	}
+    if (type == Item::itemType::WEAPON && weapon != NULL)
+    {
+        temp = weapon;
+        weapon = NULL;
+        removeMods(temp->modList);
 
-	generateChoiceDetailString();
-	generateSlotDetailMap();
-	return temp;
+    }
+    else if (type == Item::itemType::ARMOR && armor != NULL)
+    {
+        temp = armor;
+        armor = NULL;
+        removeMods(temp->modList);
+
+    }
+    else if (type == Item::itemType::TRINKET && trinket != NULL)
+    {
+        temp = trinket;
+        trinket = NULL;
+        removeMods(temp->modList);
+
+    }
+
+    updateMods();
+    generateChoiceDetailString();
+    generateSlotDetailMap();
+    return temp;
+}
+
+int Unit::addMods(std::vector<Mod>& modList)
+{
+    for (auto mod : modList)
+    {
+        this->modList.push_back(std::make_shared<Mod>(mod));
+    }
+    return 0;
+}
+
+int Unit::removeMods(std::vector<Mod>& modList)
+{
+    for (auto modToRemove : modList)
+    {
+        for (auto i = begin(this->modList); i != end(this->modList);)
+        {
+            if (modToRemove.owner == (*i)->owner)
+            {
+                i = this->modList.erase(i);
+                break;
+            }
+            else
+                ++i;
+        }
+    }
+    return 0;
+}
+
+int Unit::updateMods()
+{
+    modHitPoints = baseHitPoints;
+    modAttack = baseAttack;
+    modDefense = baseDefense;
+
+    for (auto mod : modList)
+    {
+        if (mod->type == Mod::ADD)
+        {
+            if (mod->stat == Mod::HITPOINTS)
+                modHitPoints += mod->value;
+            else if (mod->stat == Mod::ATTACK)
+                modAttack += mod->value;
+            else if (mod->stat == Mod::DEFENSE)
+                modDefense += mod->value;
+        }
+    }
+
+    float modHitPointsAddVal = modHitPoints;
+    float modAttackAddVal = modAttack;
+    float modDefenseAddVal = modDefense;
+
+    for (auto mod : modList)
+        if (mod->type == Mod::MULTIPLY)
+        {
+            if (mod->stat == Mod::HITPOINTS)
+                modHitPoints += (modHitPointsAddVal * mod->value);
+            else if (mod->stat == Mod::ATTACK)
+                modAttack += (modAttackAddVal * mod->value);
+            else if (mod->stat == Mod::DEFENSE)
+                modDefense += (modDefenseAddVal * mod->value);
+        }
+    return 0;
 }
 
 //Creates or updates a string of key details of the 
 // object for use as a choice in a Prompt.
 void Unit::generateChoiceDetailString()
 {
-	choiceDetailString = name + "(" + type + ")|H:" + std::to_string(hitPoints) 
-						+ "|A:" + std::to_string(attack) + "|D:" + std::to_string(defense);
-	return;
+    updateMods();
+    choiceDetailString = name + "(" + type + ")|H:" + std::to_string(modHitPoints) 
+                        + "|A:" + std::to_string(modAttack) + "|D:" + std::to_string(modDefense);
+    return;
 }
 
 //Creates or updates a reference of a map<string, string> that has
@@ -71,19 +144,19 @@ void Unit::generateChoiceDetailString()
 //The L# (Line Number) keys dictate the order in which they are printed.
 void Unit::generateSlotDetailMap()
 {
-	slotDetailMap.clear();
-	slotDetailMap["L1"] = name;
-	slotDetailMap["L2"] = type;
-	slotDetailMap["L3"] = "H:" + std::to_string(hitPoints)
-		+ "|A:" + std::to_string(attack) + " |D:" + std::to_string(defense);
-	if (weapon != NULL)
-		slotDetailMap["L4"] = weapon->name + ": +" + std::to_string(weapon->attackModifier) + "atk";
-	if (armor != NULL)
-		slotDetailMap["L5"] = armor->name + ": +" + std::to_string(armor->defenseModifier) + "def";
-	if (trinket != NULL)
-		slotDetailMap["L6"] = trinket->name + ": +" + std::to_string(trinket->hitPointModifier) + "hp";
+    slotDetailMap.clear();
+    slotDetailMap["L1"] = name;
+    slotDetailMap["L2"] = type;
+    slotDetailMap["L3"] = "H:" + std::to_string(modHitPoints)
+        + "|A:" + std::to_string(modAttack) + " |D:" + std::to_string(modDefense);
+    if (weapon != NULL)
+        slotDetailMap["L4"] = weapon->name + ": +" + std::to_string(weapon->attackModifier) + "atk";
+    if (armor != NULL)
+        slotDetailMap["L5"] = armor->name + ": +" + std::to_string(armor->defenseModifier) + "def";
+    if (trinket != NULL)
+        slotDetailMap["L6"] = trinket->name + ": +" + std::to_string(trinket->hitPointModifier) + "hp";
 
 
 
-	return;
+    return;
 }

--- a/ConsoleApplication1/gameObjectClasses/Unit.h
+++ b/ConsoleApplication1/gameObjectClasses/Unit.h
@@ -1,21 +1,32 @@
 #pragma once
+#include <vector>
 #include "GameObject.h"
 #include "Item.h"
+#include "Mod.h"
 class Unit :
     public GameObject
 {
 public:
-    Unit(std::string name, std::string type, int hitPoints, int attack, int defense);
-    int hitPoints;
-    int attack;
-    int defense;
+    Unit(std::string name, std::string type, int baseHitPoints, int baseAttack, int baseDefense);
+    int baseHitPoints;
+    int baseAttack;
+    int baseDefense;
+    int modHitPoints;
+    int modAttack;
+    int modDefense;
     std::string type;
     std::shared_ptr <Item> weapon;
     std::shared_ptr <Item> armor;
     std::shared_ptr <Item> trinket;
+    std::vector<std::shared_ptr <Mod>> modList;
 
     void addItem(std::shared_ptr <Item> item);
     std::shared_ptr <Item> removeItem(Item::itemType type);
+
+private:
+    int addMods(std::vector<Mod> &modList);
+    int removeMods(std::vector<Mod>& modList);
+    int updateMods();
 
 protected:
     void generateChoiceDetailString();

--- a/ConsoleApplication1/modeAndStateClasses/GS_Campaign.cpp
+++ b/ConsoleApplication1/modeAndStateClasses/GS_Campaign.cpp
@@ -5,9 +5,9 @@ GS_Campaign::GS_Campaign() :
 	prepLoopEquipmentInv("Equipment"),
 	prepLoopUnitInv("Units")
 {
-	prepLoopEquipmentInv.addItem(std::shared_ptr<GameObject>(new Item("Sword", Item::itemType::WEAPON, 10, 0, 5, 0)), 8);
-	prepLoopEquipmentInv.addItem(std::shared_ptr<GameObject>(new Item("Shield", Item::itemType::ARMOR, 10, 0, 0, 5)), 8);
-	prepLoopEquipmentInv.addItem(std::shared_ptr<GameObject>(new Item("Ring", Item::itemType::TRINKET, 10, 5, 0, 0)), 8);
+	prepLoopEquipmentInv.addItem(std::shared_ptr<GameObject>(new Item("Sword", Item::itemType::WEAPON, 10, 0, 5, 0, {})), 8);
+	prepLoopEquipmentInv.addItem(std::shared_ptr<GameObject>(new Item("Shield", Item::itemType::ARMOR, 10, 0, 0, 5, {})), 8);
+	prepLoopEquipmentInv.addItem(std::shared_ptr<GameObject>(new Item("Ring", Item::itemType::TRINKET, 10, 5, 0, 0, {})), 8);
 
 
 	prepLoopConsumablesInv.addItem(std::shared_ptr<GameObject>(new GameObject("Hearty Meal")), 20);


### PR DESCRIPTION
Mods are child objects that are intended to adjust stats on other objects like Units. Mods will be added to a parent like an Item and when the Item is given to a Unit, the mods are added to the Unit's modLists. Mod lists are then used to when calculating a Unit's modified stats. Mods currently have two varieties Add or Multiply. When calculating stats we break with traditional order of operations and add any Add mods then do any Mulitply mods.
For example: A sword will have a +1 mod. When addItem is called on the unit, the mods are added to a the Unit's modList. At the end of addItem updateMod is called then adds the +1 attack modifier to the Unit's attack. This is then reflected when the Unit's starts are portrayed. Mods give a greater amount of flexibility to how bonus's can be applied and streamline updating stat values.