### PR TITLE
Changing Item.modList from storing Mod objects to storing Mod object …

### DIFF
--- a/ConsoleApplication1/gameObjectClasses/Item.cpp
+++ b/ConsoleApplication1/gameObjectClasses/Item.cpp
@@ -1,7 +1,7 @@
 #include "Item.h"
 
 Item::Item(std::string name, itemType type, int durability, int hitPointModifier, int attackModifier, int defenseModifier,
-	std::vector<Mod> modList)
+	std::vector<std::shared_ptr<Mod>> modList)
 	: GameObject(name)
 {
 	this->name = name;
@@ -44,17 +44,17 @@ Item::Item(std::string key)
 
 	for (auto const x : itemData.modKeyList)
 	{
-		modList.emplace_back(Mod(x, std::make_shared<GameObject>(*this)));
+		modList.emplace_back(std::make_shared<Mod>(x, std::make_shared<GameObject>(*this)));
 	}
 
 	for (auto mod : modList)
 	{
-		if (mod.stat == Mod::HITPOINTS)
-			hitPointModifier = (int)std::ceil(mod.value);
-		else if (mod.stat == Mod::DEFENSE)
-			defenseModifier = (int)std::ceil(mod.value);
-		else if (mod.stat == Mod::ATTACK)
-			attackModifier = (int)std::ceil(mod.value);
+		if (mod->stat == Mod::HITPOINTS)
+			hitPointModifier = (int)std::ceil(mod->value);
+		else if (mod->stat == Mod::DEFENSE)
+			defenseModifier = (int)std::ceil(mod->value);
+		else if (mod->stat == Mod::ATTACK)
+			attackModifier = (int)std::ceil(mod->value);
 	}
 
 }

--- a/ConsoleApplication1/gameObjectClasses/Item.h
+++ b/ConsoleApplication1/gameObjectClasses/Item.h
@@ -15,10 +15,10 @@ public:
     int attackModifier;
     int defenseModifier;
     int durability;
-    std::vector<Mod> modList;
+    std::vector<std::shared_ptr<Mod>> modList;
     
     //Constructors
-    Item(std::string name, itemType type, int durability, int hitPointModifier, int attackModifier, int defenseModifier, std::vector<Mod> modList);
+    Item(std::string name, itemType type, int durability, int hitPointModifier, int attackModifier, int defenseModifier, std::vector<std::shared_ptr<Mod>> modList);
     Item(std::string key);
 
     //basic methods
@@ -39,7 +39,7 @@ private:
         modKeyList.clear();
         for (auto const x : modList)
         {
-            modKeyList.push_back(x.name);
+            modKeyList.push_back(x->name);
         }
 
         ar(CEREAL_NVP(type),

--- a/ConsoleApplication1/gameObjectClasses/Unit.cpp
+++ b/ConsoleApplication1/gameObjectClasses/Unit.cpp
@@ -101,24 +101,24 @@ std::shared_ptr <Item> Unit::removeItem(Item::itemType type)
 }
 
 //Takes a list of mods to add and adds them to the this unit's modList.
-int Unit::addMods(std::vector<Mod>& modList)
+int Unit::addMods(std::vector<std::shared_ptr<Mod>>& modList)
 {
     for (auto mod : modList)
     {
-        this->modList.push_back(std::make_shared<Mod>(mod));
+        this->modList.push_back(mod);
     }
     return 0;
 }
 
 //Takes a list of mods to remove and removes them from the 
 // this unit's modList.
-int Unit::removeMods(std::vector<Mod>& modList)
+int Unit::removeMods(std::vector<std::shared_ptr<Mod>>& modList)
 {
     for (auto modToRemove : modList)
     {
         for (auto i = begin(this->modList); i != end(this->modList);)
         {
-            if (modToRemove.owner == (*i)->owner)
+            if (modToRemove->owner == (*i)->owner)
             {
                 i = this->modList.erase(i);
                 break;
@@ -154,9 +154,9 @@ int Unit::updateMods()
     float modHitPointsAddVal = float(modHitPoints);
     float modAttackAddVal = float(modAttack);
     float modDefenseAddVal = float(modDefense);
-    float hpMultFactor = 0.;
-    float atkMultFactor = 0.;
-    float defMultFactor = 0.;
+    float hpMultFactor = 1.;
+    float atkMultFactor = 1.;
+    float defMultFactor = 1.;
 
     for (auto mod : modList)
         if (mod->type == Mod::MULTIPLY)

--- a/ConsoleApplication1/gameObjectClasses/Unit.h
+++ b/ConsoleApplication1/gameObjectClasses/Unit.h
@@ -29,8 +29,8 @@ public:
 
 
 private:
-    int addMods(std::vector<Mod> &modList);
-    int removeMods(std::vector<Mod>& modList);
+    int addMods(std::vector<std::shared_ptr<Mod>>&modList);
+    int removeMods(std::vector<std::shared_ptr<Mod>>& modList);
     int updateMods();
     
     // For serialization


### PR DESCRIPTION
…smart pointers.

Made changes to Item::modList, to now be a vector of Mod shared_ptrs instead of storing Mods directly. Had to update the addMods/removeMods methods in the Unit class because it was expecting a list of Mod objects instead of a list of Mod shared_ptrs. Also found a bug in updateMods that was zeroing out the modded stat values.

This change brings Item up to the standard that all other GameObjects (as child or reference) are stored as shared_ptrs.