### PR TITLE
v.1 of the Buffs class

### DIFF
--- a/ConsoleApplication1/ConsoleApplication1.cpp
+++ b/ConsoleApplication1/ConsoleApplication1.cpp
@@ -12,6 +12,7 @@
 #include "gameObjectClasses/Unit.h"
 #include "gameObjectClasses/Rule.h"
 #include "gameObjectClasses/RuleSet.h"
+#include "gameObjectClasses/Buff.h"
 
 
 
@@ -31,12 +32,9 @@ int main()
 
     //newCampaign.preCombatLoop();
 
-    Item myItem("Sword");
-    RuleSet myRuleSet("WeaponCheck");
-    Rule myRule("Weapon>0");
-
-    std::cout << "MultiTagCheck: " << newCampaign.multiTagCheck(myItem, myRuleSet) << "\n";
-    std::cout << "TagCheck: " << newCampaign.tagCheck(myItem, myRule) << "\n";
-
+    std::shared_ptr<Buff> myBuff = std::make_shared<Buff>("TestBuff");
+    Unit myUnit("Ryan1");
+    myUnit.addBuff(myBuff);
+    myUnit.removeBuff(myBuff);
 
 }

--- a/ConsoleApplication1/gameObjectClasses/Buff.cpp
+++ b/ConsoleApplication1/gameObjectClasses/Buff.cpp
@@ -1,0 +1,56 @@
+#include "Buff.h"
+
+Buff::Buff(std::string name, int durability, std::vector<std::shared_ptr<Mod>> modList, std::vector<std::shared_ptr<GameObject>> abilityList)
+	: GameObject(name),
+	durability(durability),
+	modList(modList),
+	abilityList(abilityList)
+	{}
+
+//Takes a key and loads the object from the json archive.
+Buff::Buff(std::string key)
+	: GameObject(key),
+	durability(),
+	modList(),
+	abilityList()
+{
+	Buff buffData;
+	try
+	{
+		std::fstream file;
+		file.open("resources/jsonArchives/Buff.json");
+		cereal::JSONInputArchive archive(file);
+		archive(cereal::make_nvp(key, buffData));
+	}
+	catch (const cereal::Exception& e)
+	{
+			std::cout << "Error loading Buff: " << e.what() << std::endl;
+				std::exit(1);
+	}
+	for (auto const& mod : buffData.modKeyList)
+		modList.emplace_back(std::make_shared<Mod>(mod, std::make_shared<GameObject>(*this)));
+	//ability object needs to be updated later once Abilities class is made.
+	for (auto const& ability : buffData.abilityKeyList)
+		this->abilityList.push_back(std::make_shared<GameObject>(ability));
+	for (auto const& tag : buffData.tagKeyList)
+		tags.emplace(std::make_pair(tag, std::make_shared<GameObject>(*this)));
+	this->durability = buffData.durability;
+}
+
+//NOT FOR REGULAR USE, this is for making a blank object for cereal.
+Buff::Buff()
+	: GameObject(""),
+	durability(),
+	modList(),
+	abilityList()
+{}
+
+//NOT FOR REGULAR USE, this is to save off objects to the Buff json archive.
+void Buff::save()
+{
+	std::fstream file;
+	file.open("resources/jsonArchives/Buff.json", std::ios::app);
+	cereal::JSONOutputArchive archive(file);
+	auto const objname = this->name;
+	archive(cereal::make_nvp(objname, * this));
+}

--- a/ConsoleApplication1/gameObjectClasses/Buff.h
+++ b/ConsoleApplication1/gameObjectClasses/Buff.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "GameObject.h"
+#include "Mod.h"
+
+class Buff :
+    public GameObject
+{
+public:
+    //Basic attributes
+    int durability;
+    std::vector<std::shared_ptr<Mod>> modList;
+    std::vector<std::shared_ptr<GameObject>> abilityList; // temp until Abilities are implemented
+
+    //Constructors
+    Buff(std::string name, int durability, std::vector<std::shared_ptr<Mod>> modList, std::vector<std::shared_ptr<GameObject>> abilityList);
+    Buff(std::string key);
+
+    //Basic methods
+
+
+private:
+    //For serialization
+    std::vector<std::string> modKeyList;
+    std::vector<std::string> abilityKeyList;
+    std::vector<std::string> tagKeyList;
+    Buff();
+    void save();
+    friend class cereal::access;
+    template <class Archive>
+    void serialize(Archive& ar)
+    {
+        modKeyList.clear();
+        for (auto const x : modList)
+	        modKeyList.push_back(x->name);
+        abilityKeyList.clear();
+        for (auto const x : abilityList)
+	        abilityKeyList.push_back(x->name);
+        tagKeyList.clear();
+        for (auto const x : tags)
+	        tagKeyList.push_back(x.first);
+        ar(CEREAL_NVP(durability),
+            CEREAL_NVP(modKeyList),
+            CEREAL_NVP(abilityKeyList),
+            CEREAL_NVP(tagKeyList));
+	}
+};
+

--- a/ConsoleApplication1/gameObjectClasses/Unit.cpp
+++ b/ConsoleApplication1/gameObjectClasses/Unit.cpp
@@ -122,6 +122,47 @@ std::shared_ptr <Item> Unit::removeItem(Item::itemType type)
     return temp;
 }
 
+//Adds a buff to the unit's buffList as well as the 
+// mods, abilities, and tags of the buff.
+void Unit::addBuff(std::shared_ptr<Buff> buff)
+{
+	buffList.push_back(buff);
+	addMods(buff->modList);
+	//addAbilities(buff->abilityList);
+	addTags(buff->tags);
+	updateMods();
+	generateChoiceDetailString();
+	generateSlotDetailMap();
+	return;
+}
+
+//Removes a buff from the unit's buffList as well as the
+// mods, abilities, and tags of the buff.
+std::shared_ptr <Buff> Unit::removeBuff(std::shared_ptr<Buff> buff)
+{
+    std::shared_ptr<Buff> temp;
+    for (auto i = begin(buffList); i != end(buffList);)
+    {
+        temp = buffList[std::distance(buffList.begin(), i)];
+
+        if (buff == buff)
+        {
+			i = buffList.erase(i);
+
+			break;
+		}
+		else
+			++i;
+	}
+	removeMods(buff->modList);
+	//removeAbilities(buff->abilityList);
+	removeTags(buff->tags);
+	updateMods();
+	generateChoiceDetailString();
+	generateSlotDetailMap();
+	return temp;
+}
+
 //Takes a list of mods to add and adds them to the this unit's modList.
 int Unit::addMods(std::vector<std::shared_ptr<Mod>>& modList)
 {

--- a/ConsoleApplication1/gameObjectClasses/Unit.h
+++ b/ConsoleApplication1/gameObjectClasses/Unit.h
@@ -2,6 +2,7 @@
 #include "GameObject.h"
 #include "Item.h"
 #include "Mod.h"
+#include "Buff.h"
 class Unit :
     public GameObject
 {
@@ -18,6 +19,7 @@ public:
     std::shared_ptr <Item> armor;
     std::shared_ptr <Item> trinket;
     std::vector<std::shared_ptr <Mod>> modList;
+    std::vector<std::shared_ptr <Buff>> buffList;
 
     //Constructors
     Unit(std::string name, std::string type, int baseHitPoints, int baseAttack, int baseDefense);
@@ -26,6 +28,8 @@ public:
     //Basic methods
     void addItem(std::shared_ptr <Item> item);
     std::shared_ptr <Item> removeItem(Item::itemType type);
+    void addBuff(std::shared_ptr <Buff> buff);
+    std::shared_ptr <Buff> removeBuff(std::shared_ptr<Buff> buff);
 
 
 private:
@@ -36,6 +40,7 @@ private:
     // For serialization
     std::vector<std::string> modKeyList;
     std::vector<std::string> tagKeyList;
+    std::vector<std::string> buffKeyList;
     std::string weaponKey;
     std::string armorKey;
     std::string trinketKey;
@@ -54,8 +59,12 @@ private:
         modKeyList.clear();
         for (auto const x : modList)
             modKeyList.push_back(x->name);
+        tagKeyList.clear();
         for (auto const x: tags)
             tagKeyList.push_back(x.first);
+        buffKeyList.clear();
+        for (auto const x : buffList)
+            buffKeyList.push_back(x->name);
         ar(CEREAL_NVP(type),
         CEREAL_NVP(baseHitPoints),
         CEREAL_NVP(baseAttack),
@@ -64,11 +73,11 @@ private:
         CEREAL_NVP(armorKey),
         CEREAL_NVP(trinketKey),
         CEREAL_NVP(modKeyList),
-        CEREAL_NVP(tagKeyList)
+        CEREAL_NVP(tagKeyList),
+        CEREAL_NVP(buffKeyList)
         );
     }
 protected:
     void generateChoiceDetailString();
     void generateSlotDetailMap();
 };
-

--- a/ConsoleApplication1/resources/jsonArchives/Buff.json
+++ b/ConsoleApplication1/resources/jsonArchives/Buff.json
@@ -1,0 +1,15 @@
+{
+    "TestBuff": {
+		"durability": 5,
+        "modKeyList": [
+            "myTestMod"
+        ],
+		"abilityKeyList": [
+			"myFakeAbility"
+		],
+        "tagKeyList": [
+            "testTag",
+            "testTag2"
+        ]
+    }
+}

--- a/ConsoleApplication1/resources/jsonArchives/Unit.json
+++ b/ConsoleApplication1/resources/jsonArchives/Unit.json
@@ -13,22 +13,8 @@
         "tagKeyList": [
             "testTag",
             "testTag2"
-        ]
-    },
-    "Ryan2": {
-        "type": "Mouse",
-        "baseHitPoints": 10,
-        "baseAttack": 1,
-        "baseDefense": 0,
-        "weaponKey": "",
-        "armorKey": "",
-        "trinketKey": "",
-        "modKeyList": [
-            
         ],
-        "tagKeyList": [
-            "testTag",
-            "testTag2"
-        ]
+		"buffKeyList": [
+		]
     }
 }


### PR DESCRIPTION
So far adding and removing Buffs to Units is working. I think that's all we need at this point. It may be that I want to add a slot on items to also hold buffs.
Buffs are an extremely flexible class that are essentially containers to hold mods, abilities, and tags. For example, a Buff could be used to Level a Unit. It would hold a mod to increase Level, various stats, hold tags like "Level2", and/or newly unlocked abilities. Then the buff gets applied to the Unit. 
Buffs can also be used to add tags for status changes on Units. For example, if you only want Units to be able to fed once a turn, you might give a consumable two buffs. One buff with the food buff, and a 2nd buff with the tag "FedThisTurn" that way, a rule check can be done for FedThisTurn, to prevent it from being fed again. Then the 2nd buff can have a durability of 1 turn, so that by the next turn that buff will be removed, and you can feed the Unit again.