### PR TITLE
Consuambles v.1

### DIFF
--- a/ConsoleApplication1/ConsoleApplication1.cpp
+++ b/ConsoleApplication1/ConsoleApplication1.cpp
@@ -12,6 +12,8 @@
 #include "gameObjectClasses/Unit.h"
 #include "gameObjectClasses/Rule.h"
 #include "gameObjectClasses/RuleSet.h"
+#include "gameObjectClasses/Buff.h"
+#include "gameObjectClasses/Consumable.h"
 
 
 
@@ -22,6 +24,11 @@ void printBreak()
 
 }
 
+void consumableTest()
+{
+    Consumable myConsumable("TestConsumable");
+    std::cout << myConsumable.name << std::endl;
+}
 
 int main()
 {
@@ -31,12 +38,6 @@ int main()
 
     //newCampaign.preCombatLoop();
 
-    Item myItem("Sword");
-    RuleSet myRuleSet("WeaponCheck");
-    Rule myRule("Weapon>0");
-
-    std::cout << "MultiTagCheck: " << newCampaign.multiTagCheck(myItem, myRuleSet) << "\n";
-    std::cout << "TagCheck: " << newCampaign.tagCheck(myItem, myRule) << "\n";
-
+    consumableTest();
 
 }

--- a/ConsoleApplication1/gameObjectClasses/Consumable.cpp
+++ b/ConsoleApplication1/gameObjectClasses/Consumable.cpp
@@ -1,0 +1,54 @@
+#include "Consumable.h"
+
+Consumable::Consumable(std::string name, consumableType type, std::vector<std::shared_ptr<Buff>> buffList) :
+    GameObject(name),
+    type(type),
+    buffList(buffList)
+{}
+
+//Takes a key and loads the object from the json archive.
+Consumable::Consumable(std::string key) :
+    GameObject(key),
+    type(),
+    ruleSet(),
+    buffList()
+{
+    Consumable consumableData;
+    try
+    {
+        std::ifstream file("resources/jsonArchives/Consumable.json");
+        if (file.fail())
+            std::cout << "fail\n";
+        cereal::JSONInputArchive archive(file);
+        archive(cereal::make_nvp(key, consumableData));
+    }
+    catch (const cereal::Exception& e)
+    {
+        std::cout << "Error loading Consumable: " << e.what() << std::endl;
+        std::exit(1);
+    }
+    for (auto const& buff : consumableData.buffKeyList)
+        buffList.emplace_back(std::make_shared<Buff>(buff));
+    for (auto const& tag : consumableData.tagKeyList)
+        tags.emplace(std::make_pair(tag, std::make_shared<GameObject>(*this)));
+    this->type = consumableData.type;
+    this->ruleSet = std::make_shared<RuleSet>(consumableData.ruleSetKey);
+}
+
+//NOT FOR REGULAR USE, this is for making a blank object for cereal.
+Consumable::Consumable() :
+    GameObject(""),
+    type(),
+    ruleSet(),
+    buffList()
+{}
+
+//NOT FOR REGULAR USE, this is to save off objects to the Consumable json archive.
+void Consumable::save()
+{
+    std::fstream file;
+    file.open("resources/jsonArchives/Consumable.json", std::ios::app);
+    cereal::JSONOutputArchive archive(file);
+    auto const objname = this->name;
+    archive(cereal::make_nvp(objname, * this));
+}

--- a/ConsoleApplication1/gameObjectClasses/Consumable.h
+++ b/ConsoleApplication1/gameObjectClasses/Consumable.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "GameObject.h"
+#include "Buff.h"
+#include "RuleSet.h"
+
+class Consumable :
+    public GameObject
+{
+public:
+    enum consumableType : std::uint8_t { POTION, FOOD, SCROLL, BOOK, OTHER };
+
+
+    //Basic attributes
+    consumableType type;
+    std::vector<std::shared_ptr<Buff>> buffList;
+    std::shared_ptr<RuleSet> ruleSet;
+
+    //Constructors
+    Consumable(std::string name, consumableType type, std::vector<std::shared_ptr<Buff>> buffList);
+    Consumable(std::string key);
+
+    //Basic methods
+
+private:
+    //For serialization
+    std::string ruleSetKey;
+    std::vector<std::string> buffKeyList;
+    std::vector<std::string> tagKeyList;
+    Consumable();
+    void save();
+    friend class cereal::access;
+    template <class Archive>
+    void serialize(Archive& ar)
+    {
+        if (ruleSet != NULL)
+            ruleSetKey = ruleSet->name;
+        buffKeyList.clear();
+        for (auto const x : buffList)
+            buffKeyList.push_back(x->name);
+        tagKeyList.clear();
+        for (auto const x : tags)
+            tagKeyList.push_back(x.first);
+        ar(CEREAL_NVP(type),
+            CEREAL_NVP(ruleSetKey),
+            CEREAL_NVP(buffKeyList),
+            CEREAL_NVP(tagKeyList));
+    }
+
+};
+

--- a/ConsoleApplication1/resources/jsonArchives/Consumable.json
+++ b/ConsoleApplication1/resources/jsonArchives/Consumable.json
@@ -1,0 +1,12 @@
+{
+	"TestConsumable": {
+		"type": 1,
+		"ruleSetKey": "TestRuleSet",
+		"buffKeyList": [
+			"TestBuff"
+		],
+		"tagKeyList": [
+			"Consumable"
+		]
+	}
+}


### PR DESCRIPTION
Consumables were relatively easy to implmement, though I did spend a couple hours looking for a really basic bug that I made. (I thought it was really complex so I looked past it for the longest time. Turned out to be a simple issue of accessing null memory.) Anyway, consumables are primarily a way to pass around buffs without attaching them to an item, giving much greater flexibility for adding mods, tags, and eventually abilities. We are also going to be using Consumables to level characters, but there are going to need to be several updates before then. Two of those updates are going to be major refactor of the code where I'll move stats and items into maps.